### PR TITLE
Add Proxem API support

### DIFF
--- a/assets/js/helper-suggested-tags.js
+++ b/assets/js/helper-suggested-tags.js
@@ -89,6 +89,17 @@ jQuery(document).ready(function() {
 		});
 		return false;
 	});
+	
+	// Proxem API
+	jQuery("a.proxem").click(function(event) {
+		event.preventDefault();
+	
+		jQuery('#st_ajax_loading').show();
+		jQuery("#suggestedtags .container_clicktags").load( ajaxurl + '?action=simpletags&stags_action=tags_from_proxem', {content:getContentFromEditor(),title:jQuery("#title").val(),tags:jQuery("#tags-input").val()}, function(){
+			registerClickTags();
+		});
+		return false;
+	});
 });
 
 function getContentFromEditor() {

--- a/inc/class.admin.suggest.php
+++ b/inc/class.admin.suggest.php
@@ -56,7 +56,8 @@ class SimpleTags_Admin_Suggest {
 		$title .= '<a class="alchemyapi" href="#suggestedtags">' . __( 'AlchemyAPI', 'simpletags' ) . '</a>&nbsp;&nbsp;-&nbsp;&nbsp;';
 		$title .= '<a class="zemanta" href="#suggestedtags">' . __( 'Zemanta', 'simpletags' ) . '</a>&nbsp;&nbsp;-&nbsp;&nbsp;';
 		$title .= '<a class="datatxt" href="#suggestedtags">' . __( 'dataTXT', 'simpletags' ) . '</a>&nbsp;&nbsp;-&nbsp;&nbsp;';
-		$title .= '<a class="tag4site" href="#suggestedtags">' . __( 'Tag4Site.RU', 'simpletags' ) . '</a>';
+		$title .= '<a class="tag4site" href="#suggestedtags">'.__('Tag4Site.RU', 'simpletags').'</a>&nbsp;&nbsp;-&nbsp;&nbsp;';
+		$title .= '<a class="proxem" href="#suggestedtags">'.__('Proxem', 'simpletags').'</a>';
 
 		return $title;
 	}
@@ -121,6 +122,9 @@ class SimpleTags_Admin_Suggest {
 				case 'tags_from_local_db' :
 					self::ajax_suggest_local();
 					break;
+				case 'tags_from_proxem' :
+					self::ajax_proxem_api();
+				break;	
 			}
 		}
 	}
@@ -538,6 +542,59 @@ class SimpleTags_Admin_Suggest {
 			echo '<div class="clear"></div>';
 		}
 
+		exit();
+	}
+	/**
+	 * Suggest tags from ProxemAPI
+	 *
+	 */
+	public static function ajax_proxem_api() {
+		status_header( 200 );
+		header("Content-Type: text/html; charset=" . get_bloginfo('charset'));
+
+		// API Key ?
+		if ( SimpleTags_Plugin::get_option_value('proxem_key') == '' ) {
+			echo '<p>'.__('Proxem API need an API key to work. You can register on service website to obtain a key and set it on Simple Tags options.', 'simpletags').'</p>';
+			exit();
+		}
+
+		// Get data
+		$content = stripslashes($_POST['content']) .' '. stripslashes($_POST['title']);
+		$content = trim($content);
+		if ( empty($content) ) {
+			echo '<p>'.__('No text was sent.', 'simpletags').'</p>';
+			exit();
+		}
+
+		// Build params
+		$response = wp_remote_post( 'https://proxem-thematization.p.mashape.com/api/wikiAnnotator/'. SimpleTags_Plugin::get_option_value('proxem_lang').'/GetCategories?nbtopcat=20', array('headers' => array(
+			'X-Mashape-Key' 	 => SimpleTags_Plugin::get_option_value('proxem_key'),
+			'Accept' => "application/json",
+			'Content-Type' 		 => "text/plain"
+		), 'body' => $content));
+		
+		if( !is_wp_error($response) && $response != null ) {
+			if ( wp_remote_retrieve_response_code($response) == 200 ) {
+				$data = wp_remote_retrieve_body($response);
+				
+			}
+		}
+		
+		$data = json_decode($data);
+		
+		if ( $data == false || !isset($data->categories) ) {
+			return false;
+		}
+
+		if ( empty($data->categories) ) {
+			echo '<p>'.__('No results from Proxem API.', 'simpletags').'</p>';
+			exit();
+		}
+
+		foreach ( (array) $data->categories as $term ) {
+			echo '<span class="local">'.esc_html($term->name).'</span>'."\n";
+		}
+		echo '<div class="clear"></div>';
 		exit();
 	}
 }

--- a/inc/class.admin.suggest.php
+++ b/inc/class.admin.suggest.php
@@ -567,11 +567,11 @@ class SimpleTags_Admin_Suggest {
 		}
 
 		// Build params
-		$response = wp_remote_post( 'https://proxem-thematization.p.mashape.com/api/wikiAnnotator/'. SimpleTags_Plugin::get_option_value('proxem_lang').'/GetCategories?nbtopcat=20', array('headers' => array(
+		$response = wp_remote_post( 'https://proxem-thematization.p.mashape.com/api/wikiAnnotator/GetCategories?nbtopcat=10', array('headers' => array(
 			'X-Mashape-Key' 	 => SimpleTags_Plugin::get_option_value('proxem_key'),
 			'Accept' => "application/json",
 			'Content-Type' 		 => "text/plain"
-		), 'body' => $content));
+		), 'body' => $content, 'timeout' => 15));
 		
 		if( !is_wp_error($response) && $response != null ) {
 			if ( wp_remote_retrieve_response_code($response) == 200 ) {
@@ -583,6 +583,7 @@ class SimpleTags_Admin_Suggest {
 		$data = json_decode($data);
 		
 		if ( $data == false || !isset($data->categories) ) {
+			var_dump($response);
 			return false;
 		}
 

--- a/inc/helper.options.admin.php
+++ b/inc/helper.options.admin.php
@@ -155,13 +155,7 @@ return array(
 			__('Proxem API Key', 'simpletags'), 
 			'text', 
 			'regular-text',
-			__('You can create an API key from <a href="https://www.mashape.com/proxem/ontology-based-topic-detection">service website</a>', 'simpletags')),
-		array(
-			'proxem_lang', 
-			__('Proxem API Language', 'simpletags'), 
-			'text', 
-			'regular-text',
-			__('The lang of your document', 'simpletags'))
+			__('You can create an API key from <a href="https://www.mashape.com/proxem/ontology-based-topic-detection">service website</a>', 'simpletags'))
 	),
 	'auto-links'     => array(
 		array(

--- a/inc/helper.options.admin.php
+++ b/inc/helper.options.admin.php
@@ -149,7 +149,19 @@ return array(
 			'text',
 			'regular-text',
 			__( 'Default: 0.6', 'simpletags' )
-		)
+		),
+		array(
+			'proxem_key', 
+			__('Proxem API Key', 'simpletags'), 
+			'text', 
+			'regular-text',
+			__('You can create an API key from <a href="https://www.mashape.com/proxem/ontology-based-topic-detection">service website</a>', 'simpletags')),
+		array(
+			'proxem_lang', 
+			__('Proxem API Language', 'simpletags'), 
+			'text', 
+			'regular-text',
+			__('The lang of your document', 'simpletags'))
 	),
 	'auto-links'     => array(
 		array(

--- a/inc/helper.options.default.php
+++ b/inc/helper.options.default.php
@@ -30,6 +30,8 @@ return array(
 	'alchemy_api'            => '',
 	'zemanta_key'            => '',
 	'tag4site_key'           => '',
+	'proxem_key'		=> '', 
+	'proxem_lang'		=> substr(get_locale(), 0, 2), 
 	'autocomplete_type'      => 'input',
 	'autocomplete_min'       => 0,
 	'autocomplete_mode'      => '',


### PR DESCRIPTION
We add the support of Proxem API, a new ontology-based topic detection available on Mashape. 